### PR TITLE
Fixing typescript error Re-exporting a type

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -207,7 +207,7 @@ export interface ContainerCreateResponse {
   message?: string;
 }
 
-export {
+export type {
   ListContainer,
   Port,
 };


### PR DESCRIPTION
Fixes #2 
```
error: TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
  ListContainer
 ```