### PR TITLE
Enhancement: Allow passing of direct connection options

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -3,19 +3,23 @@ import { HttpClient, HttpQuery, HttpRequest } from "./httpClient.ts";
 import { RegistryAuth } from "./auth.ts";
 
 export class DockerClient {
-  socketAddress: string;
+  options: Deno.ConnectOptions;
   authConfig: RegistryAuth | null;
   client: () => Promise<HttpClient>;
 
-  constructor(socketAddress: string, authConfig: RegistryAuth | null = null) {
-    this.socketAddress = socketAddress;
+  constructor(options: string|Deno.ConnectOptions, authConfig: RegistryAuth | null = null) {
+    if(typeof options == "string"){
+      this.options = <any> { transport: "unix", path: options };
+    } else {
+      this.options = options;
+    }
     this.authConfig = authConfig;
     this.client = this.init;
   }
 
   async init(): Promise<HttpClient> {
     const conn = await Deno.connect(
-      <any> { transport: "unix", path: this.socketAddress },
+      this.options
     );
     return new HttpClient(conn);
   }

--- a/index.ts
+++ b/index.ts
@@ -5,8 +5,8 @@ import { DockerClient } from "./client/client.ts";
 export default class Docker {
   containers: Container;
 
-  constructor(socketAddress: string, auth: RegistryAuth | null = null) {
-    const client = new DockerClient(socketAddress, auth);
+  constructor(options: string|Deno.ConnectOptions, auth: RegistryAuth | null = null) {
+    const client = new DockerClient(options, auth);
     this.containers = new Container(client);
   }
 }


### PR DESCRIPTION
This allows you to setup the client with an instance of `Deno.ConnectOptions` directly.

Allows using this library on windows for instance by changing the connection parameter to something like.

```typescript
const docker = new Docker({transport:"tcp",hostname:"localhost", port:2375});
```

This change is backwards compatible, and should break nothing, as any code passing a connection string will be converted to a unix style connection options parameter just as before.

Tested on windows using the following code

```typescript
const docker = new Docker({transport:"tcp",hostname:"localhost", port:2375});
docker.containers.list()
    .then(r => r.map(c => c.Names))
    .then(console.log);
```

With the result showing all containers I had running
```javascript
[
  [ "/devstack_haproxy_1" ],
  [ "/devstack_redis-commander_1" ],
  [ "/devstack_redis_1" ],
  [ "/devstack_core-app_1" ],
  [ "/devstack_mysql-shared_1" ],
  [ "/devstack_mysql-core_1" ]
]
```