### PR TITLE
fix typo in PublicPOrt

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -38,7 +38,7 @@ enum PortType {
 interface Port {
   IP?: string;
   PrivatePort: number;
-  PublicPOrt?: number;
+  PublicPort?: number;
   Type: PortType;
 }
 


### PR DESCRIPTION
Fix typo in `PublicPOrt` to `PublicPort`