### PR TITLE
Expand HostConfig options

### DIFF
--- a/lib/types/container/container.ts
+++ b/lib/types/container/container.ts
@@ -44,6 +44,14 @@ interface Port {
 
 interface HostConfig {
   NetworkMode?: string;
+  PortBindings?: {
+    [key: string]: PortBinding[];
+  };
+}
+
+interface PortBinding {
+  HostIp: string;
+  HostPort: string;
 }
 
 interface NetworkSettings {


### PR DESCRIPTION
This is a pretty nifty library. I think this is all that needs to be done to expand the HostConfig to allow port mappings between host and container.